### PR TITLE
Upgrade PostgreSQL version to 9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python: "3.6"
+addons:
+  postgresql: "9.6"
 env:
     - DJANGO_SETTINGS_MODULE=config.settings.test
 install:


### PR DESCRIPTION
Django 2.1 uses WITH ORDINALITY in testing
which breaks with the default PostgreSQL version